### PR TITLE
fix: 底部导航栏避让系统导航栏

### DIFF
--- a/src/main/kotlin/com/water/widget/ui/DashboardScreen.kt
+++ b/src/main/kotlin/com/water/widget/ui/DashboardScreen.kt
@@ -32,11 +32,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -150,7 +152,8 @@ fun DashboardScreen(
         drawContent()
     }
     val pageTopPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 28.dp
-    val bottomContentPadding = 92.dp
+    val bottomContentPadding = 92.dp +
+        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     var showAccountSwitcher by rememberSaveable { mutableStateOf(false) }
     var showAppearanceSettings by rememberSaveable { mutableStateOf(false) }
     var showSupportDialog by rememberSaveable { mutableStateOf(false) }
@@ -896,7 +899,8 @@ private fun BottomTabs(
                 colors = BlurColors(
                     blendColors = listOf(BlendColorEntry(colors.surface.copy(alpha = 0.64f)))
                 )
-            ),
+            )
+            .windowInsetsPadding(WindowInsets.navigationBars),
         shape = RectangleShape,
         color = Color.Transparent,
         contentColor = colors.onSurface,


### PR DESCRIPTION
修复 #4。

## 问题

5.4.0 在开启系统三键导航的设备上，应用底部导航栏与系统导航键重叠，底部标签无法正常点击。5.3.0 无此问题。

复现环境：红米 K70 / Android 16 / v5.4.0

## 原因

targetSdk 35 在 Android 15+ 强制 edge-to-edge，窗口内容默认延伸到系统栏之下。

`BottomTabs` 是固定在 `Alignment.BottomCenter` 的 64dp 浮层，且不可滚动，因此会直接绘制在系统导航栏区域内、被其覆盖，用户没有任何办法把它移出来。

项目此前只在 `pageTopPadding` 处理了 `statusBars`，全项目没有任何 `navigationBars` 避让。

## 改动

- `BottomTabs` 的 Surface 追加 `windowInsetsPadding(WindowInsets.navigationBars)`。刻意放在 `textureBlur(...)` **之后**：模糊层按外层尺寸绘制，仍铺满到屏幕底边保持视觉连续，padding 只收缩内容区，标签被抬到系统导航栏之上。
- `bottomContentPadding` 相应加上导航栏高度，避免各页滚动内容的末项被抬高后的底栏遮挡。

手势导航下该 inset 接近 0，无需按导航模式分支判断，两种模式自适应。

其余页面（积分 / 钱包 / 账号）为可滚动列表，内容可划出遮挡区，本次未改动。

## 验证

- `./gradlew assembleRelease` 构建通过
- 红米 K70 / Android 16 真机安装验证：
  - 三键导航模式：底部标签恢复正常点击，毛玻璃仍延伸至屏幕底边
  - 全面屏手势导航模式：显示正常，底栏无多余留白
