### PR TITLE
fix: 在设备登录被拒绝时提示检查登录信息

### DIFF
--- a/src/main/java/com/water/widget/IlifeApi.java
+++ b/src/main/java/com/water/widget/IlifeApi.java
@@ -28,6 +28,8 @@ public class IlifeApi {
     static final String CID = BuildConfig.API_CID;
     private static final String SIGN_SALT = BuildConfig.SIGN_SALT;
     private static final String UA = "WaterWidget/" + BuildConfig.VERSION_NAME + " (Android)";
+    private static final String DEVICE_LOGIN_REJECTED_MESSAGE =
+            "设备登录信息未被接受，请检查是否填反或重新完成设备登录";
 
     public interface ImgCallback {
         void onResult(byte[] bytes, String err);
@@ -420,7 +422,7 @@ public class IlifeApi {
                 } else if (code == -99) {
                     cb.onResult(null, "TOKEN_EXPIRED");
                 } else if (code == -21) {
-                    cb.onResult(null, useApp ? msg : "需要设备控制登录信息，请先在账户中添加");
+                    cb.onResult(null, useApp ? DEVICE_LOGIN_REJECTED_MESSAGE : "需要设备控制登录信息，请先在账户中添加");
                 } else if (code == -88) {
                     cb.onResult(null, "未签约代扣协议，请在服务端完成签约后再使用");
                 } else if (code == -87) {
@@ -467,7 +469,7 @@ public class IlifeApi {
                 } else if (code == -99) {
                     cb.onResult(null, "TOKEN_EXPIRED");
                 } else if (code == -21) {
-                    cb.onResult(null, msg);
+                    cb.onResult(null, DEVICE_LOGIN_REJECTED_MESSAGE);
                 } else if (code == -88) {
                     cb.onResult(null, "未签约代扣协议，请在服务端完成签约后再使用");
                 } else if (code == -87) {

--- a/src/main/java/com/water/widget/WaterService.java
+++ b/src/main/java/com/water/widget/WaterService.java
@@ -373,7 +373,9 @@ public class WaterService extends Service {
                 }
             }
         }
-        if (!posted) Toast.makeText(this, title + "：" + text, Toast.LENGTH_LONG).show();
+        // 需要用户处理的失败（如设备登录被拒绝）总是弹 Toast：
+        // 用户多半正停留在刚点过启动的主页，只发通知容易被忽略。
+        if (recovery || !posted) Toast.makeText(this, title + "：" + text, Toast.LENGTH_LONG).show();
     }
 
     private void updateWidget(int widgetId, String status) {


### PR DESCRIPTION
手动导入的积分 Token 被放入设备登录位置后，设备启动接口可能返回 `-21` 和下载官方 App 的提示。当前客户端会将这段文案显示给用户，缺少检查登录信息的指引。

本改动在 `IlifeApi.devStart` 和 `devStartWithToken` 中，为已提供设备登录信息时的 `-21` 返回统一的本地提示：

> 设备登录信息未被接受，请检查是否填反或重新完成设备登录

这个提示给出可操作的检查方向，也避免把所有 `-21` 情况都断定为「一定填反」。没有设备登录信息时，继续提示先添加设备登录。

另外，`WaterService.showResult` 此前在通知发送成功时不再弹 Toast。用户在主页点击启动、设备登录被拒绝时，失败提示只出现在通知栏，停留在应用内容易漏看。第二个提交让需要用户处理的失败（`recovery` 为 true）在发送通知的同时也弹 Toast；其他结果保持原有逻辑。

Token 类型探测和自动纠错需要可靠的判断依据。我仅尝试过少量接口，尚未找到稳定区分两类 Token 的方法，因此将相关策略留在 issue 中讨论。本 PR 仅处理设备启动失败后的提示，不声称修复了 Token 自动纠错。

## 验证

- 基于上游 `445bcd2`，本地执行 `testDebugUnitTest lintDebug --offline --no-daemon --console=plain`。
- 现有 97 项单元测试通过，0 失败、0 跳过；这些测试不是对实际服务器响应的端到端验证。
- Lint：0 错误、29 个警告。
- 第二个提交仅改动一处条件，本地 `compileDebugJavaWithJavac` 通过。

已用同一账户验证：正确设备 Token 正常启动；错误位置导致 `-21` 时显示新提示；过期登录和其他设备错误仍按原有逻辑处理。

关联 issue：#8。