### PR TITLE
build: 为 Release 启用 R8 和资源压缩

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,12 @@ android {
             if (releaseSigningConfigured) {
                 signingConfig = signingConfigs.getByName("release")
             }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,26 @@
+# Preserve the bundled scanner and its reflectively discovered component registrars.
+# Keep these rules conservative until the minified build is verified on devices.
+-keep class com.google.mlkit.** { *; }
+-keep class com.google.android.gms.internal.mlkit_** { *; }
+-keep class * implements com.google.firebase.components.ComponentRegistrar { *; }
+
+# Optional dependencies referenced by the bundled vCard/template libraries.
+# The application does not use their servlet, scripting or desktop integrations.
+-dontwarn javax.servlet.**
+-dontwarn jakarta.servlet.**
+-dontwarn org.python.**
+-dontwarn org.zeroturnaround.**
+-dontwarn org.slf4j.**
+-dontwarn org.apache.log4j.**
+-dontwarn org.apache.avalon.**
+-dontwarn org.dom4j.**
+-dontwarn org.jaxen.**
+-dontwarn org.jdom.**
+-dontwarn org.mozilla.javascript.**
+-dontwarn com.sun.**
+-dontwarn javax.xml.bind.**
+-dontwarn freemarker.**
+-dontwarn ezvcard.**
+
+# FreeMarker loads implementation classes by name.
+-keepnames class freemarker.** { *; }


### PR DESCRIPTION
当前 Release 未开启代码和资源压缩。对同一上游基线进行本地构建对照后，可以通过 R8 和资源压缩减少发布包中保留的代码与资源，因此准备了这个优化供评估。

## 改动

- Release 启用 `isMinifyEnabled` 和 `isShrinkResources`，使用 Android 的优化规则。
- 增加针对 bundled ML Kit、反射注册入口及当前传递依赖的 ProGuard 配置。
- 此次比较保留上游的 `useLegacyPackaging = true`，将 DEX 打包方式的影响与 R8 优化分开。

变更只涉及 `app/build.gradle.kts` 和 `app/proguard-rules.pro`，基于上游 `445bcd2`。
## 本地对照

两次构建使用同一份上游代码、相同依赖和 API 配置、JDK 21、Gradle 9.5.0、AGP 9.3.0，均为未签名 Release APK。变化仅为本 PR 的 R8、资源压缩和相应规则；DEX 在两份包内均保持压缩存放。

| 指标 | 上游基线 | 本 PR | 减少 |
| --- | ---: | ---: | ---: |
| APK 文件大小 | 26.31 MB | 9.63 MB | 63.4% |
| DEX 未压缩大小合计 | 59.58 MB | 4.69 MB | 92.1% |
| DEX 在 APK 中的压缩大小合计 | 17.81 MB | 2.23 MB | — |
| DEX 文件数 | 5 | 1 | — |



## 真机安装后的存储占用

安装基于本 PR 构建的 R8 Release 测试包后，系统存储详情显示：

| 项目 | 系统显示值 |
| --- | ---: |
| 总计 | 20.71 MB |
| 应用大小 | 20.35 MB |
| 用户数据 | 352 KB |
| 缓存 | 274 KB |

<img width="1419" height="1532" alt="6" src="https://github.com/user-attachments/assets/4daa6de6-4f66-401d-bb17-a783b774357e" />


测试包使用独立包名并存安装，以上为本次系统界面显示值。

## 验证与合入前事项

- 上游基线 `assembleRelease` 构建通过。
- 本 PR 的 `testDebugUnitTest lintDebug assembleRelease --offline --no-daemon --console=plain` 通过。
- 现有 97 项单元测试通过，0 失败、0 跳过；Lint 为 0 错误、29 个警告。
- R8 和 Release 的 lintVital 检查通过，生成了优化后的 Release APK。
- 已对基于本 PR 构建的 R8 Release 测试包完成真机验证：扫码、设备启动、积分任务和登录均正常。

当前 ML Kit 的 keep 规则沿用了真机自用测试构建的保守范围，会限制一部分优化；`dontwarn` 规则也需要结合实际扫码输入和依赖用途审阅。

关联 issue：#9。